### PR TITLE
Adding config file to add Jekyll theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+remote_theme: pages-themes/leap-day@v0.2.0
+plugins:
+- jekyll-remote-theme # add this line to the plugins list if you already have one


### PR DESCRIPTION
`_config.yml` file added to try and add a Jekyll theme to the GitHub Pages documentation.