### PR TITLE
Removing commented code to pass CodeQL checks

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,6 +48,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
-        #remote_theme: pages-themes/leap-day@v0.2.0
-        #plugins:
-        #- jekyll-remote-theme # add this line to the plugins list if you already have one


### PR DESCRIPTION
Commented code caused CodeQL checks to fail. Removing unnecessary commented code from `pages.yml` file.